### PR TITLE
fix: disable CGO

### DIFF
--- a/pkgs/pinact/default.nix
+++ b/pkgs/pinact/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
-  env.CGO_ENABLED = 0;
+  CGO_ENABLED = 0;
 
   subPackages = [ "./cmd/pinact" ];
 

--- a/pkgs/pinact/default.nix
+++ b/pkgs/pinact/default.nix
@@ -15,6 +15,8 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
+  env.CGO_ENABLED = 0;
+
   subPackages = [ "./cmd/pinact" ];
 
   doCheck = false;


### PR DESCRIPTION
The original was set `CGO_ENABLED=0` by GoReleaser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the Go build configuration to enhance the consistency and reliability of the build process by compiling code without relying on external C dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->