### PR TITLE
refactor: use `env.CGO_ENABLED` instead

### DIFF
--- a/pkgs/disable-checkout-persist-credentials/default.nix
+++ b/pkgs/disable-checkout-persist-credentials/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "./cmd/disable-checkout-persist-credentials" ];
 

--- a/pkgs/duckgo/default.nix
+++ b/pkgs/duckgo/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     "-X main.appVersion=${version}"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   doCheck = false;
 

--- a/pkgs/ghalint/default.nix
+++ b/pkgs/ghalint/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "./cmd/ghalint" ];
 

--- a/pkgs/ghatm/default.nix
+++ b/pkgs/ghatm/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   subPackages = [ "./cmd/ghatm" ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   doCheck = false;
 

--- a/pkgs/gitlab-ci-verify/default.nix
+++ b/pkgs/gitlab-ci-verify/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
     "-X github.com/timo-reymann/gitlab-ci-verify/internal/buildinfo.Version=${version}"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   doCheck = false;
 

--- a/pkgs/pinact/default.nix
+++ b/pkgs/pinact/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "./cmd/pinact" ];
 


### PR DESCRIPTION
when stable, this syntax was invalid.
currently, we support unstable only, we can use this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configurations to standardize the handling of key environment settings, contributing to improved consistency and reliability in our build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->