### PR TITLE
fix: fix dapname

### DIFF
--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -49,6 +49,6 @@ src.manual = "v3.0.0"
 fetch.github = "keithamus/sort-package-json"
 
 [tsgo]
-# renovate: datasource=git-refs depName=microsoft/typescript-go
+# renovate: datasource=git-refs depName=https://github.com/microsoft/typescript-go
 src.manual = "d508afb"
 fetch.url = "https://github.com/microsoft/typescript-go/archive/$ver.zip"


### PR DESCRIPTION
git-refs datasource needs fullpath to git repo

refs: https://docs.renovatebot.com/modules/datasource/git-refs/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the dependency source configuration to use fully qualified repository URLs for improved clarity and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->