### PR TITLE
chore: fix jsonata query

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,11 +19,16 @@
         "/^nvfetcher.toml$/",
       ],
       matchStrings: [
-        '*.{ \
-          "depName": fetch.github ? fetch.github : (fetch.url ~> /^https:\\/\\/github\\.com\\/[^\\/]+?\\/[^\\/]+/ ~> $lookup("match")), \
+        '*.( \
+          $isCommitHash := src.manual ~> /^[0-9a-f]{7}$/; \
+          { \
+          "depName": fetch.github ? fetch.github : ( \
+            $url := fetch.url ~> /^https:\\/\\/github\\.com\\/([^\\/]+?\\/[^\\/]+)/; \
+            $isCommitHash ? $url.match : $url.groups[0] \
+          ), \
           "currentValue": src.manual, \
-          "datasource": src.manual ~> /^[0-9a-f]{7}$/ ? "git-refs" : "github-releases" \
-        }',
+          "datasource": $isCommitHash ? "git-refs" : "github-releases" \
+        })',
       ],
     },
   ],


### PR DESCRIPTION
depName that has "github-release" as datasource need to be `foo/bar` format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved dependency parsing logic in configuration to better distinguish between commit hashes and release versions. No visible changes to application features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->