### PR TITLE
ci: run renovate twice per day

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '15 2 * * *'
+    - cron: '15 2,14 * * *'
   workflow_dispatch: null
 jobs:
   update-by-renovate:


### PR DESCRIPTION
and run when push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Renovate workflow schedule to run twice daily instead of once, improving the frequency of dependency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->