### PR TITLE
fix: use npm package name as `packageName`

### DIFF
--- a/pkgs/claude-code/default.nix
+++ b/pkgs/claude-code/default.nix
@@ -8,9 +8,9 @@
 nodeEnv.buildNodePackage rec {
   inherit (source) pname src version;
   name = source.pname;
-  packageName = source.pname;
   buildInputs = globalBuildInputs;
 
+  packageName = "@anthropic-ai/claude-code";
   meta = with lib; {
     description = "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster";
     homepage = "https://github.com/anthropics/claude-code";


### PR DESCRIPTION
It seems be used in symlink phase and it must be npm package name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the declared package name to a fixed value for improved consistency in package identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->