### PR TITLE
ci: use renovate based on devshell instead

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
       - name: Renovate
-        run: nix run nixpkgs#renovate -- --token=${{ steps.app-token.outputs.token }} --platform=github
+        run: nix develop .#renovate --command renovate --token=${{ steps.app-token.outputs.token }} --platform=github
         env:
           LOG_LEVEL: debug
           RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/flake.nix
+++ b/flake.nix
@@ -166,6 +166,9 @@
               pkgs.nvfetcher
             ];
           };
+          renovate = pkgs.mkShell {
+            packages = [ pkgs.renovate ];
+          };
         }
       );
     };


### PR DESCRIPTION
This pull request updates the configuration for running Renovate in the GitHub Actions workflow and introduces a new shell environment for Renovate in the Nix flake configuration.

### Workflow updates:
* [`.github/workflows/renovate.yml`](diffhunk://#diff-2f2dcee4f3f279ea8d2f4cd0235f2ab917d8cf1d8e11f4f195a3816afe79af26L40-R40): Updated the Renovate command to use `nix develop` for invoking Renovate, aligning with the Nix flake development environment.

### Nix flake configuration:
* [`flake.nix`](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R169-R171): Added a new `renovate` shell environment using `pkgs.mkShell`, which includes Renovate as a package.