### PR TITLE
fix: disable claude-code auto updater

### DIFF
--- a/pkgs/claude-code/default.nix
+++ b/pkgs/claude-code/default.nix
@@ -1,14 +1,22 @@
 {
+  pkgs,
   source,
   nodeEnv,
   lib,
-  globalBuildInputs ? [ ],
+  globalBuildInputs ? [ ] ++ [ pkgs.makeWrapper ],
 }:
 
 nodeEnv.buildNodePackage rec {
   inherit (source) pname src version;
   name = source.pname;
   buildInputs = globalBuildInputs;
+
+  # `claude-code` tries to auto-update by default, this disables that functionality.
+  # https://docs.anthropic.com/en/docs/claude-code/settings#environment-variables
+  postInstall = ''
+    wrapProgram $out/bin/claude \
+      --set DISABLE_AUTOUPDATER 1
+  '';
 
   packageName = "@anthropic-ai/claude-code";
   meta = with lib; {


### PR DESCRIPTION
This pull request updates the `pkgs/claude-code/default.nix` file to enhance the build configuration and modify the behavior of the `claude-code` package. The most important changes include adding a dependency for `makeWrapper` and disabling the auto-update functionality of `claude-code`.

Build configuration updates:

* Added `pkgs.makeWrapper` to the `globalBuildInputs` to enable wrapping the `claude-code` binary. (`[pkgs/claude-code/default.nixR2-R20](diffhunk://#diff-f68f58694f85ec13d8b007153fd826d465d73f4968df675653c5828d0914c80fR2-R20)`)

Behavior modification:

* Introduced a `postInstall` step to wrap the `claude` binary and set the `DISABLE_AUTOUPDATER` environment variable to `1`, effectively disabling the auto-update functionality. (`[pkgs/claude-code/default.nixR2-R20](diffhunk://#diff-f68f58694f85ec13d8b007153fd826d465d73f4968df675653c5828d0914c80fR2-R20)`)