### PR TITLE
ci: increase timeout-minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   tests:
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         os:


### PR DESCRIPTION
CI failed often.
So we increase it to x1.5 times.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased CI tests job timeout from 30 to 45 minutes to better accommodate longer test runs and reduce intermittent CI failures.
  * No user-facing or UI changes; this update only improves build/test reliability and consistency of future releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->