### PR TITLE
ci: improve matrix readability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
         cachixName:
           - omochice
         nixPath:
-          - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixpkgs-unstable.tar.gz
-          - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz
+          - nixpkgs-unstable
+          - nixos-unstable
     runs-on: ${{ matrix.os }}
     permissions: {}
     steps:
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          nix-path: "${{ matrix.nixPath }}"
+          nix-path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/${{ matrix.nixPath }}.tar.gz
       - name: Show nixpkgs version
         run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
       - name: Setup cachix


### PR DESCRIPTION
`nixpkgs=...` is too long


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration build configuration to select Nix package sources by branch name instead of fixed URLs, enabling dynamic tarball selection per matrix entry.
  * The rest of the build workflow remains unchanged.
  * No user-facing functionality is affected, and application behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->