### PR TITLE
ci: show diff when fail job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           CHANGES=$(git diff --name-only _sources/generated.json _sources/generated.nix)
           if [ -n "$CHANGES" ]; then
-            echo "$CHANGES" >&2
+            git diff _sources/generated.json _sources/generated.nix
             exit 1
           fi
   check-renovate-config:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated CI check to print full diffs when generated artifacts change, rather than just listing filenames.
  * Exit behavior remains the same; the check still fails when changes are detected.
  * This affects only workflow logs; there are no user-facing changes.
  * No changes to application behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->