### PR TITLE
refactor: remove pipe-operators experimental feature

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -120,32 +120,43 @@
         in
         {
           check-action =
-            ''
-              actionlint --version
-              actionlint
-              ghalint --version
-              ghalint run
-            ''
-            |> runAs "check-action" [
-              pkgs.actionlint
-              pkgs.ghalint
-            ];
+            nixpkgs.lib.pipe
+              ''
+                actionlint --version
+                actionlint
+                ghalint --version
+                ghalint run
+              ''
+              [
+                (runAs "check-action" [
+                  pkgs.actionlint
+                  pkgs.ghalint
+                ])
+              ];
           check-renovate-config =
-            ''
-              renovate-config-validator renovate.json5
-            ''
-            |> runAs "check-renovate-config" [
-              pkgs.renovate
-            ];
+            nixpkgs.lib.pipe
+              ''
+                renovate-config-validator renovate.json5
+              ''
+              [
+                (runAs "check-renovate-config" [
+                  pkgs.renovate
+                ])
+              ];
           sync-readme =
-            ''
-              ${pkgs.callPackage ./scripts/generate-package-table.nix { }}/bin/generate-package-table
-              nix fmt
-            ''
-            |> runAs "sync-readme" [
-              pkgs.nix
-            ];
-          nvfetcher = "nvfetcher \"$@\"" |> runAs "nvfetcher" [ pkgs.nvfetcher ];
+            nixpkgs.lib.pipe
+              ''
+                ${pkgs.callPackage ./scripts/generate-package-table.nix { }}/bin/generate-package-table
+                nix fmt
+              ''
+              [
+                (runAs "sync-readme" [
+                  pkgs.nix
+                ])
+              ];
+          nvfetcher = nixpkgs.lib.pipe "nvfetcher \"$@\"" [
+            (runAs "nvfetcher" [ pkgs.nvfetcher ])
+          ];
         }
       );
       devShells = forAllSystems (


### PR DESCRIPTION
Replace pipe operator syntax (|>) with traditional function application
in flake.nix. Remove pipe-operators from experimental features list
in GitHub Actions Nix setup to reduce dependency on experimental features.

I want to use some packages in devbox, but it does not enable 'pipe-operators'. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Converted inline script pipelines to a two-part pipe pattern for application command handling, improving consistency.
  * Reworked package-info extraction and table generation into a consolidated pipe-based flow for clearer transformations.
  * Preserved external behavior and public interfaces; no user-facing outputs or APIs were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->