### PR TITLE
ci: add missing permissions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,9 +25,11 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             nur-packages
+          permission-checks: write
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-statuses: write
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
renovate needs below permissins:

ref: https://github.com/renovatebot/renovate/blob/6cf7cbbf/docs/usage/security-and-permissions.md#global-permissions

| Permission        | The Mend Renovate App |  Forking Renovate  | Why                                                           |
| ----------------- | :-------------------: | :----------------: | ------------------------------------------------------------- |
| Dependabot alerts |        `read`         |       `read`       | Create vulnerability fix PRs                                  |
| Administration    |        `read`         |       `read`       | Read branch protections and to be able to assign teams to PRs |
| Metadata          |        `read`         |       `read`       | Mandatory for all apps                                        |
| Checks            |  `read` and `write`   |   not applicable   | Read and write status checks                                  |
| Code              |  `read` and `write`   |       `read`       | Read for repository content and write for creating branches   |
| Commit statuses   |  `read` and `write`   | `read` and `write` | Read and write commit statuses for Renovate PRs               |
| Issues            |  `read` and `write`   | `read` and `write` | Create Dependency Dashboard or Config Warning issues          |
| Pull Requests     |  `read` and `write`   | `read` and `write` | Create update PRs                                             |
| Workflows         |  `read` and `write`   |   not applicable   | Explicit permission needed to update workflows                |

Currently thrown error is below:

```console
2026-01-17T06:16:33.4446304Z DEBUG: Caught error setting branch status - aborting (repository=Omochice/nur-packages, branch=self-hosted-renovate/cc-sdd-2.x)
2026-01-17T06:16:33.4447417Z        "err": {
2026-01-17T06:16:33.4447754Z          "message": "integration-unauthorized",
2026-01-17T06:16:33.4458317Z          "stack": "Error: integration-unauthorized\n    at handleGotError (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/util/http/github.ts:154:12)\n    at GithubHttp.handleError (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/util/http/github.ts:369:11)\n    at GithubHttp.request (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/util/http/http.ts:258:12)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at GithubHttp.requestJsonUnsafe (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/util/http/github.ts:383:20)\n    at GithubHttp.requestJson (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/util/http/http.ts:359:17)\n    at Proxy.setBranchStatus (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/modules/platform/github/index.ts:1273:5)\n    at setStatusCheck (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/workers/repository/update/branch/status-checks.ts:55:5)\n    at setStability (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/workers/repository/update/branch/status-checks.ts:93:3)\n    at processBranch (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/workers/repository/update/branch/index.ts:744:5)\n    at res.attributes (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/workers/repository/process/write.ts:177:21)\n    at writeUpdates (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/workers/repository/process/write.ts:150:17)\n    at update (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/workers/repository/process/extract-update.ts:253:11)\n    at Object.renovateRepository (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/workers/repository/index.ts:142:19)\n    at attributes (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/workers/global/index.ts:198:11)\n    at start (/nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/workers/global/index.ts:183:7)\n    at /nix/store/4bb1ckc940bxq3mpspr9qyb7z4r5qllw-renovate-42.57.1/lib/node_modules/renovate/lib/renovate.ts:19:22"
2026-01-17T06:16:33.4472191Z        },
```

So we add `checks` and `statuses`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded permissions for the Renovate automation workflow to enable write access to GitHub checks and status updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->