### PR TITLE
feat: add salesforce-cli package

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -404,6 +404,21 @@
         },
         "version": "v0.4.1"
     },
+    "salesforce-cli": {
+        "cargoLock": null,
+        "date": null,
+        "extract": null,
+        "name": "salesforce-cli",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-eEJZlabz/PmbipSqvR49XJweOl1ZBUtS/zjMIggWWYw=",
+            "type": "url",
+            "url": "https://registry.npmjs.org/@salesforce/cli/-/cli-2.133.2.tgz"
+        },
+        "version": "2.133.2"
+    },
     "slack-reminder": {
         "cargoLock": null,
         "date": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -219,6 +219,14 @@
       sha256 = "sha256-ACMRfWY/lhc3C/KVhuUyS1rgkSHGWPxZrmYt+pXupJI=";
     };
   };
+  salesforce-cli = {
+    pname = "salesforce-cli";
+    version = "2.133.2";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/@salesforce/cli/-/cli-2.133.2.tgz";
+      sha256 = "sha256-eEJZlabz/PmbipSqvR49XJweOl1ZBUtS/zjMIggWWYw=";
+    };
+  };
   slack-reminder = {
     pname = "slack-reminder";
     version = "v0.1.1";

--- a/default.nix
+++ b/default.nix
@@ -75,6 +75,9 @@ in
   octocov = pkgs.callPackage ./pkgs/octocov/default.nix { source = sources.octocov; };
   pinact = pkgs.callPackage ./pkgs/pinact/default.nix { source = sources.pinact; };
   roots = pkgs.callPackage ./pkgs/roots/default.nix { source = sources.roots; };
+  salesforce-cli = pkgs.callPackage ./pkgs/salesforce-cli/default.nix {
+    source = sources.salesforce-cli;
+  };
   slack-reminder = pkgs.callPackage ./pkgs/slack-reminder/default.nix {
     source = sources.slack-reminder;
   };

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -82,6 +82,10 @@ src.manual = "v3.9.0"
 fetch.github = "k1LoW/roots"
 src.manual = "v0.4.1"
 
+[salesforce-cli]
+fetch.url = "https://registry.npmjs.org/@salesforce/cli/-/cli-$ver.tgz"
+src.manual = "2.133.2"
+
 [slack-reminder]
 fetch.github = "skanehira/slack-reminder"
 src.manual = "v0.1.1"

--- a/pkgs/salesforce-cli/default.nix
+++ b/pkgs/salesforce-cli/default.nix
@@ -47,16 +47,13 @@ stdenv.mkDerivation rec {
 
     # Create wrapper scripts instead of symlinks because patchShebangs
     # mishandles the complex shebang `#!/usr/bin/env -S node --no-deprecation`
-    makeWrapper ${nodejs}/bin/node $out/bin/sf \
-      --add-flags "--no-deprecation" \
-      --add-flags "$out/lib/node_modules/@salesforce/cli/bin/run.js" \
-      --set SF_AUTOUPDATE_DISABLE true \
-      --set SF_DISABLE_TELEMETRY true
-    makeWrapper ${nodejs}/bin/node $out/bin/sfdx \
-      --add-flags "--no-deprecation" \
-      --add-flags "$out/lib/node_modules/@salesforce/cli/bin/run.js" \
-      --set SF_AUTOUPDATE_DISABLE true \
-      --set SF_DISABLE_TELEMETRY true
+    for cmd in sf sfdx; do
+      makeWrapper ${nodejs}/bin/node $out/bin/$cmd \
+        --add-flags "--no-deprecation" \
+        --add-flags "$out/lib/node_modules/@salesforce/cli/bin/run.js" \
+        --set SF_AUTOUPDATE_DISABLE true \
+        --set SF_DISABLE_TELEMETRY true
+    done
     runHook postInstall
   '';
 

--- a/pkgs/salesforce-cli/default.nix
+++ b/pkgs/salesforce-cli/default.nix
@@ -1,0 +1,70 @@
+{
+  source,
+  lib,
+  stdenv,
+  nodejs,
+  makeWrapper,
+  fetchNpmDeps,
+}:
+
+let
+  npmDeps = fetchNpmDeps {
+    src = source.src;
+    sourceRoot = "package";
+    hash = "sha256-mul/em8FSbrza9NAipB+w+tdAkLNGHbK8U1aRj1PLtw=";
+    npmDepsFetcherVersion = 2;
+  };
+in
+stdenv.mkDerivation rec {
+  inherit (source) pname version;
+  src = source.src;
+  sourceRoot = "package";
+
+  nativeBuildInputs = [
+    nodejs
+    makeWrapper
+  ];
+
+  # The shrinkwrap was generated on Linux (no fsevents) which causes `npm ci`
+  # to fail on macOS. Use `npm install --offline` which is more lenient.
+  configurePhase = ''
+    runHook preConfigure
+    export HOME="$TMPDIR"
+    export npm_config_cache="$TMPDIR/npm_cache"
+    cp -r ${npmDeps}/. "$npm_config_cache"
+    chmod -R u+w "$npm_config_cache"
+    npm install --offline --legacy-peer-deps --ignore-scripts --no-audit --no-fund
+    runHook postConfigure
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/node_modules/@salesforce/cli
+    cp -r . $out/lib/node_modules/@salesforce/cli
+    mkdir -p $out/bin
+
+    # Create wrapper scripts instead of symlinks because patchShebangs
+    # mishandles the complex shebang `#!/usr/bin/env -S node --no-deprecation`
+    makeWrapper ${nodejs}/bin/node $out/bin/sf \
+      --add-flags "--no-deprecation" \
+      --add-flags "$out/lib/node_modules/@salesforce/cli/bin/run.js" \
+      --set SF_AUTOUPDATE_DISABLE true \
+      --set SF_DISABLE_TELEMETRY true
+    makeWrapper ${nodejs}/bin/node $out/bin/sfdx \
+      --add-flags "--no-deprecation" \
+      --add-flags "$out/lib/node_modules/@salesforce/cli/bin/run.js" \
+      --set SF_AUTOUPDATE_DISABLE true \
+      --set SF_DISABLE_TELEMETRY true
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Salesforce CLI for interacting with Salesforce orgs and services";
+    homepage = "https://github.com/salesforcecli/cli";
+    changelog = "https://github.com/salesforcecli/cli/releases/tag/${version}";
+    license = licenses.asl20;
+    mainProgram = "sf";
+  };
+}

--- a/pkgs/salesforce-cli/default.nix
+++ b/pkgs/salesforce-cli/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     export npm_config_cache="$TMPDIR/npm_cache"
     cp -r ${npmDeps}/. "$npm_config_cache"
     chmod -R u+w "$npm_config_cache"
-    npm install --offline --legacy-peer-deps --ignore-scripts --no-audit --no-fund
+    npm install --offline --legacy-peer-deps --ignore-scripts --no-audit --no-fund --omit=dev
     runHook postConfigure
   '';
 


### PR DESCRIPTION
## Summary

Add `@salesforce/cli` (sf/sfdx) v2.133.2 as a new Nix package.

## Details

Salesforce CLI is not available in nixpkgs. The package is built from the npm registry tarball which contains pre-compiled JavaScript. `buildNpmPackage` could not be used because `npm ci` fails on macOS: the npm-shrinkwrap.json bundled in the tarball was generated on Linux and lacks `fsevents`, causing a sync error. Instead, `stdenv.mkDerivation` with `fetchNpmDeps` and `npm install --offline` is used for a more lenient dependency resolution. Binary wrappers are created with `makeWrapper` because `patchShebangs` mishandles the complex shebang `#!/usr/bin/env -S node --no-deprecation`. Auto-update and telemetry are disabled via environment variables.

## Confirmation

- `nix build .#salesforce-cli` succeeds
- `sf --version` outputs `@salesforce/cli/2.133.2`
- `sf help` lists available commands

## Limitation

No known limitations.