### PR TITLE
feat!: deprecated llm packages

### DIFF
--- a/pkgs/cc-sdd/default.nix
+++ b/pkgs/cc-sdd/default.nix
@@ -5,20 +5,24 @@
   globalBuildInputs ? [ ],
 }:
 
-nodeEnv.buildNodePackage rec {
-  inherit (source) pname src version;
-  # keep-sorted start block=yes
-  buildInputs = globalBuildInputs;
-  meta.description = ''
-    Spec-driven development (SDD) for your team's workflow.
-    Kiro style commands that enforce structured requirements→design→tasks workflow and steering, transforming how you build with AI.
-    Support Claude Code, Codex, Cursor, GitHub Copilot, Gemini CLI and Windsurf.
-  '';
-  meta.homepage = "https://github.com/gotalab/cc-sdd";
-  meta.changelog = "https://github.com/gotalab/cc-sdd/releases/tag/v${version}";
-  meta.license = lib.licenses.mit;
-  meta.mainProgram = "cc-sdd";
-  name = source.pname;
-  packageName = source.pname;
-  # keep-sorted end
-}
+lib.warn
+  "cc-sdd: this package is deprecated in favor of numtide/llm-agents.nix (https://github.com/numtide/llm-agents.nix); use that flake instead."
+  (
+    nodeEnv.buildNodePackage rec {
+      inherit (source) pname src version;
+      # keep-sorted start block=yes
+      buildInputs = globalBuildInputs;
+      meta.description = ''
+        Spec-driven development (SDD) for your team's workflow.
+        Kiro style commands that enforce structured requirements→design→tasks workflow and steering, transforming how you build with AI.
+        Support Claude Code, Codex, Cursor, GitHub Copilot, Gemini CLI and Windsurf.
+      '';
+      meta.homepage = "https://github.com/gotalab/cc-sdd";
+      meta.changelog = "https://github.com/gotalab/cc-sdd/releases/tag/v${version}";
+      meta.license = lib.licenses.mit;
+      meta.mainProgram = "cc-sdd";
+      name = source.pname;
+      packageName = source.pname;
+      # keep-sorted end
+    }
+  )

--- a/pkgs/ccusage/default.nix
+++ b/pkgs/ccusage/default.nix
@@ -5,17 +5,21 @@
   globalBuildInputs ? [ ],
 }:
 
-nodeEnv.buildNodePackage rec {
-  inherit (source) pname src version;
-  name = source.pname;
-  packageName = source.pname;
-  buildInputs = globalBuildInputs;
+lib.warn
+  "ccusage: this package is deprecated in favor of numtide/llm-agents.nix (https://github.com/numtide/llm-agents.nix); use that flake instead."
+  (
+    nodeEnv.buildNodePackage rec {
+      inherit (source) pname src version;
+      name = source.pname;
+      packageName = source.pname;
+      buildInputs = globalBuildInputs;
 
-  meta = with lib; {
-    description = "A CLI tool for analyzing Claude Code usage from local JSONL files.";
-    homepage = "https://github.com/ryoppippi/ccusage";
-    changelog = "https://github.com/ryoppippi/ccusage/releases/tag/v${version}";
-    license = licenses.mit;
-    mainProgram = "ccusage";
-  };
-}
+      meta = with lib; {
+        description = "A CLI tool for analyzing Claude Code usage from local JSONL files.";
+        homepage = "https://github.com/ryoppippi/ccusage";
+        changelog = "https://github.com/ryoppippi/ccusage/releases/tag/v${version}";
+        license = licenses.mit;
+        mainProgram = "ccusage";
+      };
+    }
+  )

--- a/pkgs/claude-code/default.nix
+++ b/pkgs/claude-code/default.nix
@@ -6,28 +6,32 @@
   globalBuildInputs ? [ ] ++ [ pkgs.makeWrapper ],
 }:
 
-nodeEnv.buildNodePackage rec {
-  inherit (source) pname src version;
-  name = source.pname;
-  buildInputs = globalBuildInputs;
+lib.warn
+  "claude-code: this package is deprecated in favor of numtide/llm-agents.nix (https://github.com/numtide/llm-agents.nix); use that flake instead."
+  (
+    nodeEnv.buildNodePackage rec {
+      inherit (source) pname src version;
+      name = source.pname;
+      buildInputs = globalBuildInputs;
 
-  # `claude-code` tries to auto-update by default, this disables that functionality.
-  # https://docs.anthropic.com/en/docs/claude-code/settings#environment-variables
-  postInstall = ''
-    wrapProgram $out/bin/claude \
-      --set DISABLE_AUTOUPDATER 1
-  '';
+      # `claude-code` tries to auto-update by default, this disables that functionality.
+      # https://docs.anthropic.com/en/docs/claude-code/settings#environment-variables
+      postInstall = ''
+        wrapProgram $out/bin/claude \
+          --set DISABLE_AUTOUPDATER 1
+      '';
 
-  packageName = "@anthropic-ai/claude-code";
-  meta = with lib; {
-    description = "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster";
-    homepage = "https://github.com/anthropics/claude-code";
-    downloadPage = "https://www.npmjs.com/package/@anthropic-ai/claude-code/v/${version}";
-    license = licenses.unfree;
-    mainProgram = "claude";
-  };
+      packageName = "@anthropic-ai/claude-code";
+      meta = with lib; {
+        description = "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster";
+        homepage = "https://github.com/anthropics/claude-code";
+        downloadPage = "https://www.npmjs.com/package/@anthropic-ai/claude-code/v/${version}";
+        license = licenses.unfree;
+        mainProgram = "claude";
+      };
 
-  production = true;
-  bypassCache = true;
-  reconstructLock = true;
-}
+      production = true;
+      bypassCache = true;
+      reconstructLock = true;
+    }
+  )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Deprecations
* Three packages are now marked as deprecated in favor of `numtide/llm-agents.nix`. Users are encouraged to migrate to the recommended alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->