### PR TITLE
fix: make veridex actually run on Linux and stop shipping data files on PATH

### DIFF
--- a/pkgs/veridex/default.nix
+++ b/pkgs/veridex/default.nix
@@ -1,22 +1,12 @@
 {
-  fetchFromGitiles,
+  fetchzip,
   lib,
   stdenvNoCC,
   unzip,
 }:
 let
   version = "android-15.0.0_r25";
-  target =
-    if stdenvNoCC.hostPlatform.isDarwin then
-      {
-        path = "veridex-mac.zip";
-        hash = "sha256-7wpNcsCfMaQZ5hvDLUG+JD7AM7oRBFVnl8yaURQ2Mkc=";
-      }
-    else
-      {
-        path = "veridex-linux.zip";
-        hash = "sha256-IaFtakCDE/VeWAT3Okojon8ajuFzAe/wvY7kEBGajAM=";
-      };
+  archive = if stdenvNoCC.hostPlatform.isDarwin then "veridex-mac.zip" else "veridex-linux.zip";
 in
 stdenvNoCC.mkDerivation {
   inherit version;
@@ -25,16 +15,20 @@ stdenvNoCC.mkDerivation {
 
   nativeBuildInputs = [ unzip ];
 
-  src = fetchFromGitiles {
-    url = "https://android.googlesource.com/platform/prebuilts/runtime";
-    rev = version;
-    hash = target.hash;
+  # Gitiles can archive a single directory, and only appcompat is needed.
+  # Archiving the whole prebuilts/runtime repository downloads hundreds of
+  # megabytes to reach the same two zips.
+  src = fetchzip {
+    name = "veridex-prebuilts-${version}";
+    url = "https://android.googlesource.com/platform/prebuilts/runtime/+archive/refs/tags/${version}/appcompat.tar.gz";
+    stripRoot = false;
+    hash = "sha256-slqJwsUwfcDvN8oWF8YM4z+wk51qMqICR3yF5dxSFaY=";
   };
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
-    unzip appcompat/${target.path} -d $out/bin
+    unzip ${archive} -d $out/bin
     runHook postInstall
   '';
 

--- a/pkgs/veridex/default.nix
+++ b/pkgs/veridex/default.nix
@@ -1,15 +1,16 @@
 {
+  autoPatchelfHook,
   fetchzip,
   makeWrapper,
   lib,
-  stdenvNoCC,
+  stdenv,
   unzip,
 }:
 let
   version = "android-15.0.0_r25";
-  archive = if stdenvNoCC.hostPlatform.isDarwin then "veridex-mac.zip" else "veridex-linux.zip";
+  archive = if stdenv.hostPlatform.isDarwin then "veridex-mac.zip" else "veridex-linux.zip";
 in
-stdenvNoCC.mkDerivation {
+stdenv.mkDerivation {
   inherit version;
 
   pname = "veridex";
@@ -17,7 +18,10 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [
     makeWrapper
     unzip
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
 
   dontBuild = true;
 

--- a/pkgs/veridex/default.nix
+++ b/pkgs/veridex/default.nix
@@ -3,12 +3,11 @@
   lib,
   stdenvNoCC,
   unzip,
-  pkgs,
 }:
 let
   version = "android-15.0.0_r25";
   target =
-    if pkgs.stdenv.hostPlatform.isDarwin then
+    if stdenvNoCC.hostPlatform.isDarwin then
       {
         path = "veridex-mac.zip";
         hash = "sha256-7wpNcsCfMaQZ5hvDLUG+JD7AM7oRBFVnl8yaURQ2Mkc=";

--- a/pkgs/veridex/default.nix
+++ b/pkgs/veridex/default.nix
@@ -9,6 +9,8 @@
 
 let
   version = "android-15.0.0_r25";
+  # The macOS prebuilt is an x86_64 Mach-O binary, which aarch64-darwin runs
+  # through Rosetta 2. Upstream ships no aarch64 build to prefer over it.
   archive = if stdenv.hostPlatform.isDarwin then "veridex-mac.zip" else "veridex-linux.zip";
 in
 stdenv.mkDerivation {
@@ -52,7 +54,9 @@ stdenv.mkDerivation {
   meta.license = lib.licenses.asl20;
   meta.mainProgram = "appcompat.sh";
   meta.platforms = [
-    "x86_64-linux"
     "aarch64-darwin"
+    "x86_64-darwin"
+    "x86_64-linux"
   ];
+  meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
 }

--- a/pkgs/veridex/default.nix
+++ b/pkgs/veridex/default.nix
@@ -1,29 +1,19 @@
 {
+  lib,
+  stdenv,
   autoPatchelfHook,
   fetchzip,
   makeWrapper,
-  lib,
-  stdenv,
   unzip,
 }:
+
 let
   version = "android-15.0.0_r25";
   archive = if stdenv.hostPlatform.isDarwin then "veridex-mac.zip" else "veridex-linux.zip";
 in
 stdenv.mkDerivation {
-  inherit version;
-
   pname = "veridex";
-
-  nativeBuildInputs = [
-    makeWrapper
-    unzip
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
-
-  dontBuild = true;
+  inherit version;
 
   # Gitiles can archive a single directory, and only appcompat is needed.
   # Archiving the whole prebuilts/runtime repository downloads hundreds of
@@ -34,6 +24,16 @@ stdenv.mkDerivation {
     stripRoot = false;
     hash = "sha256-slqJwsUwfcDvN8oWF8YM4z+wk51qMqICR3yF5dxSFaY=";
   };
+
+  nativeBuildInputs = [
+    makeWrapper
+    unzip
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+
+  dontBuild = true;
 
   # appcompat.sh only takes its prebuilt code path when veridex and the data
   # files sit next to it, so the archive stays whole under libexec and is
@@ -47,14 +47,12 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
-    description = "Given an APK, finds API uses that fall into the blocklist/max-target-X/unsupported APIs.";
-    homepage = "https://android.googlesource.com/platform/art/+/refs/tags/${version}/tools/veridex/";
-    license = licenses.asl20;
-    platforms = [
-      "x86_64-linux"
-      "aarch64-darwin"
-    ];
-    mainProgram = "appcompat.sh";
-  };
+  meta.description = "Given an APK, finds API uses that fall into the blocklist/max-target-X/unsupported APIs.";
+  meta.homepage = "https://android.googlesource.com/platform/art/+/refs/tags/${version}/tools/veridex/";
+  meta.license = lib.licenses.asl20;
+  meta.mainProgram = "appcompat.sh";
+  meta.platforms = [
+    "x86_64-linux"
+    "aarch64-darwin"
+  ];
 }

--- a/pkgs/veridex/default.nix
+++ b/pkgs/veridex/default.nix
@@ -1,5 +1,6 @@
 {
   fetchzip,
+  makeWrapper,
   lib,
   stdenvNoCC,
   unzip,
@@ -13,7 +14,12 @@ stdenvNoCC.mkDerivation {
 
   pname = "veridex";
 
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [
+    makeWrapper
+    unzip
+  ];
+
+  dontBuild = true;
 
   # Gitiles can archive a single directory, and only appcompat is needed.
   # Archiving the whole prebuilts/runtime repository downloads hundreds of
@@ -25,10 +31,15 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-slqJwsUwfcDvN8oWF8YM4z+wk51qMqICR3yF5dxSFaY=";
   };
 
+  # appcompat.sh only takes its prebuilt code path when veridex and the data
+  # files sit next to it, so the archive stays whole under libexec and is
+  # reached through a wrapper. A symlink into bin would make the script look
+  # for its siblings in bin and fall back to the Android tree layout.
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin
-    unzip ${archive} -d $out/bin
+    mkdir -p $out/libexec
+    unzip ${archive} -d $out/libexec/veridex
+    makeWrapper $out/libexec/veridex/appcompat.sh $out/bin/appcompat.sh
     runHook postInstall
   '';
 


### PR DESCRIPTION
## Summary

Repackage veridex so the Linux binary is patched for Nix, the data files move out of `$out/bin`, and the source is fetched once instead of twice with conflicting hashes.

## Details

The Linux `veridex` is a dynamically linked ELF asking for `/lib64/ld-linux-x86-64.so.2`, and nothing patched it, so the package built fine and then failed to start. Fixing that needs `autoPatchelfHook`, which resolves libc through `$NIX_BINTOOLS/nix-support`, so the derivation moves from `stdenvNoCC` to `stdenv`.

The source carried two different hashes for one url and rev. `fetchFromGitiles` is a `fetchzip` over an immutable tag, so only one content hash exists and at most one of them could have been right. Gitiles accepts a directory path in its archive URL, so fetching `appcompat` alone removes the per-platform key and cuts the download from the whole `prebuilts/runtime` repository, which did not finish within ten minutes locally, to about 20 MB.

`appcompat.sh` only takes its prebuilt code path when `veridex` and the data files are its own siblings, so the archive stays whole under `libexec` and `bin` gets a `makeWrapper` wrapper rather than a symlink, which would resolve `BASH_SOURCE` to `bin` and fall through to the Android tree layout.

## Confirmation

Built on aarch64-darwin and ran `$out/bin/appcompat.sh`, which reached `Required argument '--dex-file=' not provided.` from the `veridex` binary, so the wrapper, the binary and the data files all resolve.

CI built the derivation on x86_64-linux with `auto-patchelf-hook` in its closure and the build succeeded. `autoPatchelfHook` fails the build on any unresolvable library, so the interpreter was rewritten and every `NEEDED` entry, including `libc.so.6` and `libgcc_s.so.1`, resolved.

Fetched the new archive twice locally and confirmed the two downloads are identical, and confirmed the installed files are byte-identical to what the previous whole-repository fetch produced. The source store path CI produced on x86_64-linux matches the one fetched on aarch64-darwin.

Confirmed the structural first commit leaves both the x86_64-linux and the aarch64-darwin derivation hash unchanged.

## Limitation

The Linux binary was built but never executed, since no Linux machine was available here.

`$out/bin/veridex` no longer exists. The bare binary needs the flags file and the stubs, and `appcompat.sh` is what upstream documents.

veridex has no version automation. It is absent from `_sources`, untracked by renovate, and the README shows its version as `unknown`. That is left to a separate PR.

https://claude.ai/code/session_01UzrxA3XgEJXzbYFArDxbQm